### PR TITLE
Removes unused util to fix an importError

### DIFF
--- a/pomo_state.py
+++ b/pomo_state.py
@@ -2,7 +2,7 @@
 import sys
 
 from constants import STATE_FILE, USE_FONT_AWESOME_ICONS
-from util import timedelta_str, read_stage_and_time, get_pct_completed, Stage
+from util import timedelta_str, read_stage_and_time, Stage
 
 # FontAwesome chars
 if USE_FONT_AWESOME_ICONS:


### PR DESCRIPTION
Traceback (most recent call last):
  File "pomo_state.py", line 5, in <module>
    from util import timedelta_str, read_stage_and_time, get_pct_completed, Stage
ImportError: cannot import name 'get_pct_completed' from 'util'