### PR TITLE
Fix to show message when rest is completed

### DIFF
--- a/pomo_runner.py
+++ b/pomo_runner.py
@@ -69,4 +69,4 @@ else:
         notify_user("Pomodoro completed", "Time for the rest stage")
         run_stage(Stage.REST)
         pomo_state.prep_for_active()
-        notify_user("Rest stage completed")
+        notify_user("Rest stage completed", "Time to get back to work")


### PR DESCRIPTION
I was getting an error because `notify_user` expects a second argument.